### PR TITLE
not execute methods when disconnected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test: run-deps run-test-game-server run-tests kill-game-server kill-deps
 killall: kill-game-server kill-deps
 
 run-test-game-server:
+	@echo 'starting game server'
 	@rm -rf /tmp/kublai-pomelo.log
 	@POMELO_REDIS_PORT=7677 MONGO_URL=mongodb://localhost:27017/mqtt node example/app.js host=127.0.0.1 port=3334 clientPort=3010 frontend=true serverType=connector 2>&1 > /tmp/kublai-pomelo.log &
 	@sleep 3
@@ -31,7 +32,7 @@ run-tests:
 
 run-deps:
 	@docker-compose up -d
-	@until echo "echo 'db.stats().ok' | mongo mongo:27017/test --quiet" | docker exec --interactive pernilongo_mongo_1 /bin/bash -; do warn 'Waiting for Mongo...' && sleep 1; done
+	@until echo "echo 'db.stats().ok' | mongo mongo:27017/test --quiet" | docker exec --interactive pernilongo_mongo_1 /bin/bash -; do echo 'Waiting for Mongo...' && sleep 1; done
 	@sleep 10
 
 kill-deps:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 services:
   redis:
     image: redis:3.2.4-alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   redis:
-    image: redis:3.2.4-alpine
+    image: redis:3.2
     ports:
       - "7677:6379"
   mongo:
-    image: mongo:3.0.15-wheezy
+    image: mongo:3.6
     ports:
       - "27017:27017"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3'
 services:
   redis:
     image: redis:3.2.4-alpine

--- a/lib/services/pernilongo.js
+++ b/lib/services/pernilongo.js
@@ -48,12 +48,12 @@ PernilongoService.prototype.setupMongoClient = function (){
 
     db.s.topology.on('close', function() {
       logger.info('Pernilongo Mongo disconnected')
-      connected = false
+      self.connected = false
     })
 
     db.s.topology.on('reconnect', function() {
       logger.info('Pernilongo Mongo reconnected')
-      connected = true
+      self.connected = true
     })
   })
 }
@@ -71,7 +71,7 @@ PernilongoService.prototype.getUserRoomAuthorization = function(gameId, userId, 
 }
 
 PernilongoService.prototype.registerPlayer = function (user, pass){
-  if (!connected) {
+  if (!this.connected) {
     logger.error('Pernilongo not connected to Mongo, skipping')
     return Promise.resolve()
   }
@@ -88,7 +88,7 @@ PernilongoService.prototype.registerPlayer = function (user, pass){
 }
 
 PernilongoService.prototype.authorizePlayerInRooms = function (user, rooms){
-  if (!connected) {
+  if (!this.connected) {
     logger.error('Pernilongo not connected to Mongo, skipping')
     return Promise.resolve()
   }
@@ -108,7 +108,7 @@ PernilongoService.prototype.authorizePlayerInRooms = function (user, rooms){
 }
 
 PernilongoService.prototype.unauthorizePlayerInRooms = function(user, rooms){
-  if (!connected) {
+  if (!this.connected) {
     logger.error('Pernilongo not connected to Mongo, skipping')
     return Promise.resolve()
   }
@@ -121,7 +121,7 @@ PernilongoService.prototype.unauthorizePlayerInRooms = function(user, rooms){
 }
 
 PernilongoService.prototype.registerPlayerAndAuthorizeInRooms = function(user, pass, rooms){
-  if (!connected) {
+  if (!this.connected) {
     logger.error('Pernilongo not connected to Mongo, skipping')
     return Promise.resolve()
   }
@@ -131,7 +131,7 @@ PernilongoService.prototype.registerPlayerAndAuthorizeInRooms = function(user, p
 }
 
 PernilongoService.prototype.authorizePlayerInRoomsWithExpireTime = function (user, rooms, expireTime){
-  if (!connected) {
+  if (!this.connected) {
     logger.error('Pernilongo not connected to Mongo, skipping')
     return Promise.resolve()
   }

--- a/lib/services/pernilongo.js
+++ b/lib/services/pernilongo.js
@@ -19,6 +19,7 @@ const PernilongoService = function (mongoUrl, app, component) {
   this.app = app
   this._component = component
   this.connecting = false
+  this.connected = false
 }
 
 module.exports = function (mongoUrl, app, component) {
@@ -37,12 +38,23 @@ PernilongoService.prototype.setupMongoClient = function (){
   MongoClient.connect(this.mongoUrl,
     { reconnectInterval: 2000, reconnectTries: Infinity }, function(err, db) {
     self.connecting = false
+    self.connected = true
     if (err) {
       // TODO: Do something
       return
     }
     self.users = bluebird.promisifyAll(db.collection('mqtt_user'))
     self.acl = bluebird.promisifyAll(db.collection('mqtt_acl'))
+
+    db.s.topology.on('close', function() {
+      logger.info('Pernilongo Mongo disconnected')
+      connected = false
+    })
+
+    db.s.topology.on('reconnect', function() {
+      logger.info('Pernilongo Mongo reconnected')
+      connected = true
+    })
   })
 }
 
@@ -59,6 +71,11 @@ PernilongoService.prototype.getUserRoomAuthorization = function(gameId, userId, 
 }
 
 PernilongoService.prototype.registerPlayer = function (user, pass){
+  if (!connected) {
+    logger.error('Pernilongo not connected to Mongo, skipping')
+    return Promise.resolve()
+  }
+
   const PBKDF2Hash = (password.getPBKDF2Hash(pass)).split('$');
   const hashedPass = PBKDF2Hash[4];
   const salt = PBKDF2Hash[3];
@@ -71,6 +88,11 @@ PernilongoService.prototype.registerPlayer = function (user, pass){
 }
 
 PernilongoService.prototype.authorizePlayerInRooms = function (user, rooms){
+  if (!connected) {
+    logger.error('Pernilongo not connected to Mongo, skipping')
+    return Promise.resolve()
+  }
+
   if (!this.acl) {
     this.setupMongoClient()
     return Promise.resolve()
@@ -86,6 +108,11 @@ PernilongoService.prototype.authorizePlayerInRooms = function (user, rooms){
 }
 
 PernilongoService.prototype.unauthorizePlayerInRooms = function(user, rooms){
+  if (!connected) {
+    logger.error('Pernilongo not connected to Mongo, skipping')
+    return Promise.resolve()
+  }
+
   if (!this.acl) {
     this.setupMongoClient()
     return Promise.resolve()
@@ -94,11 +121,21 @@ PernilongoService.prototype.unauthorizePlayerInRooms = function(user, rooms){
 }
 
 PernilongoService.prototype.registerPlayerAndAuthorizeInRooms = function(user, pass, rooms){
+  if (!connected) {
+    logger.error('Pernilongo not connected to Mongo, skipping')
+    return Promise.resolve()
+  }
+
   return this.registerPlayer(user, pass).
     then(() => this.authorizePlayerInRooms(user, rooms))
 }
 
 PernilongoService.prototype.authorizePlayerInRoomsWithExpireTime = function (user, rooms, expireTime){
+  if (!connected) {
+    logger.error('Pernilongo not connected to Mongo, skipping')
+    return Promise.resolve()
+  }
+
   if (!this.acl) {
     this.setupMongoClient()
     return Promise.resolve()


### PR DESCRIPTION
This feature is supposed to help when MongoDB is down and the lib should not hang on any call. 

It detects when Mongo is down and sets a flag `connected = false`. Then all method calls logs an error and returns a promise with resolve. 